### PR TITLE
Especificando a versão do compilador e jre a ser utilizado.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,20 @@
 		<connection>scm:git:git://github.com/rlazoti/vraptor-authentication</connection>
 		<developerConnection>scm:git:git@github.com:rlazoti/vraptor-authentication.git</developerConnection>
 	</scm>
+	
+	<build>
+	    <plugins>
+		    <plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-compiler-plugin</artifactId>
+			    <version>2.5.1</version>
+				    <configuration>
+					    <source>1.5</source>
+					    <target>1.5</target>
+			    </configuration>
+		    </plugin>
+	    </plugins>
+	</build>
 
 	<distributionManagement>
 		<repository>


### PR DESCRIPTION
Olá.
Houve um problema na compilação em meu computador, pois não estava explicita a versão do compilador a ser utilizado.
Fiz o ajuste no pom.
